### PR TITLE
Fix documentation typos and metadata

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,6 +16,6 @@ Imports:
     qs,
     readr
 Encoding: UTF-8
-Packaged: 2025-07-14 12:49:22.339709
+Packaged: 2024-07-14 12:49:22.339709
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.3.1

--- a/Development/Development.bac
+++ b/Development/Development.bac
@@ -14,7 +14,7 @@
 #' @title Convert a Column to Row Names in a Tibble or DataFrame
 #'
 #' @description Converts the first column (or a specified column) of a dataframe or tibble into row names.
-#' This function differs from `tibble::column_to_rownames` in that it takes column names or inices and
+#' This function differs from `tibble::column_to_rownames` in that it takes column names or indices and
 #' it offers the option to sanitize row names using `make.names`, provides a warning if there are
 #' duplicated values in the row name column
 #'
@@ -27,7 +27,7 @@
 #' @param as_df Boolean indicating whether to convert the input to a dataframe if it's not already one.
 #'              Default: TRUE.
 #' @param warn Warn user if row names pre-exist.
-#' @param ... Pass arguments to make.names()..
+#' @param ... Pass arguments to make.names().
 #' @export
 
 column.2.row.names <- function(
@@ -359,7 +359,7 @@ read.simple.csv <- function(
 
 # _________________________________________________________________________________________________
 #' @title read.simple.ssv
-#' @description Space separeted values. Read in a file with excel style data:
+#' @description Space separated values. Read in a file with excel style data:
 #' rownames in col1, headers SHIFTED. The header should start with a
 #' TAB / First column name should be empty.
 #' @param ... Multiple simple variables to parse.

--- a/Development/ReadWriter.orig.R
+++ b/Development/ReadWriter.orig.R
@@ -78,7 +78,7 @@ read.simple.csv <- function(...,  colnames = TRUE, coltypes = NULL, wRownames = 
   return(read_in)
 }
 
-read.simple.ssv <- function(..., sep_ = " ", colnames = TRUE, wRownames = TRUE, NaReplace = TRUE, coltypes = NULL) { # Space separeted values. Read in a file with excel style data: rownames in col1, headers SHIFTED. The header should start with a TAB / First column name should be empty.
+read.simple.ssv <- function(..., sep_ = " ", colnames = TRUE, wRownames = TRUE, NaReplace = TRUE, coltypes = NULL) { # Space separated values. Read in a file with excel style data: rownames in col1, headers SHIFTED. The header should start with a TAB / First column name should be empty.
   pfn = kollapse(...) # merge path and filename
   read_in = suppressWarnings(readr::read_delim( pfn, delim = sep_, col_names = colnames, col_types = coltypes ))
   iprint("New variable dim: ", dim(read_in) - 0:1)

--- a/R/Deprecated.Functions.R
+++ b/R/Deprecated.Functions.R
@@ -26,7 +26,7 @@ read.simple.xls <- function(pfn = kollapse(...), row_namePos = NULL, ..., header
   .Deprecated("read.simple.xlsx")
 
   if (!require("gdata")) {
-    print("Please install gplots: install.packages('gdata')")
+    print("Please install gdata: install.packages('gdata')")
   }
   if (grepl("^~/", pfn)) {
     iprint("You cannot use the ~/ in the file path! It is replaced by '~/'.")

--- a/R/list.of.functions.in.ReadWriter.md
+++ b/R/list.of.functions.in.ReadWriter.md
@@ -35,16 +35,16 @@ read.simple.csv. Read in a file with excel style data: rownames in col1,
 read.simple.csv.named.vector. Read in a file with excel style data: rownames in col1,
 
 - #### 12 `read.simple.ssv()`
-read.simple.ssv. Read in a data frame (csv), and extact a value and a name column, and convert them
+read.simple.ssv. Read in a data frame (csv), and extract a value and a name column, and convert them
 
 - #### 13 `read.simple.tsv.named.vector()`
-read.simple.tsv.named.vector. Space separeted values. Read in a file with excel style data:
+read.simple.tsv.named.vector. Space separated values. Read in a file with excel style data:
 
 - #### 14 `read.simple.xlsx()`
 Read a multi-sheet XLSX easily. Read in a file with excel style named vectors, names in col1,
 
 - #### 15 `write.simplest()`
-Append or write a vector to standard file, one element per line.. Reads specified sheets from an XLSX file into a list of data frames.
+Append or write a vector to standard file, one element per line. Reads specified sheets from an XLSX file into a list of data frames.
 
 - #### 16 `write.simple()`
 Write Simple. Alternative to clipboard. This function takes a vector and appends it

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ source("https://raw.githubusercontent.com/vertesy/ReadWriter/main/R/ReadWriter.R
 Updated: 2024/10/24 13:48
 
 - #### 1 `column.2.row.names()`
-Convert a Column to Row Names in a Tibble or DataFrame. Converts the first column (or a specified column) of a dataframe or tibble into row names.  This function differs from `tibble::column_to_rownames` in that it takes column names or inices and  it offers the option to sanitize row names using `make.names`, provides a warning if there are  duplicated values in the row name column 
+Convert a Column to Row Names in a Tibble or DataFrame. Converts the first column (or a specified column) of a dataframe or tibble into row names.  This function differs from `tibble::column_to_rownames` in that it takes column names or indices and  it offers the option to sanitize row names using `make.names`, provides a warning if there are  duplicated values in the row name column
 
 - #### 2 `FirstCol2RowNames()`
 FirstCol2RowNames. Set First Col to Row Names
@@ -77,10 +77,10 @@ read.simple.tsv. Read in a file with excel style data: rownames in col1,  header
 read.simple.csv. Read in a file with excel style data: rownames in col1,  headers SHIFTED. The header should start with a TAB / First column name  should be empty.
 
 - #### 11 `read.simple.csv.named.vector()`
-read.simple.csv.named.vector. Read in a data frame (csv), and extact a value and a name column, and convert them  to a named vector. By default, it assumes the names in the first column and the values  excel style named vectors, names in col1,  headers SHIFTED. The header should start with a TAB / First column name  should be empty.
+read.simple.csv.named.vector. Read in a data frame (csv), and extract a value and a name column, and convert them  to a named vector. By default, it assumes the names in the first column and the values  excel style named vectors, names in col1,  headers SHIFTED. The header should start with a TAB / First column name  should be empty.
 
 - #### 12 `read.simple.ssv()`
-read.simple.ssv. Space separeted values. Read in a file with excel style data:  rownames in col1, headers SHIFTED. The header should start with a  TAB / First column name should be empty.
+read.simple.ssv. Space separated values. Read in a file with excel style data:  rownames in col1, headers SHIFTED. The header should start with a  TAB / First column name should be empty.
 
 - #### 13 `read.simple.tsv.named.vector()`
 read.simple.tsv.named.vector. Read in a file with excel style named vectors, names in col1,  headers SHIFTED. The header should start with a TAB / First column name  should be empty.
@@ -89,7 +89,7 @@ read.simple.tsv.named.vector. Read in a file with excel style named vectors, nam
 Read a multi-sheet XLSX easily. Reads specified sheets from an XLSX file into a list of data frames.               It allows customization of column names, row names, and trimming of white spaces. 
 
 - #### 15 `write.simplest()`
-Append or write a vector to standard file, one element per line.. Alternative to clipboard. This function takes a vector and appends it  to a specified file. 
+Append or write a vector to standard file, one element per line. Alternative to clipboard. This function takes a vector and appends it  to a specified file.
 
 - #### 16 `write.simple()`
 Write Simple. Writes a matrix-like R object (e.g., a data frame) to a file as tab-separated    values (.tsv). The output filename can be auto-generated from the variable's name or manually    specified. The file is saved in the specified output directory or the current working directory.    The path and variable name can be passed separately and will be concatenated to form the filename.

--- a/man/column.2.row.names.Rd
+++ b/man/column.2.row.names.Rd
@@ -31,11 +31,11 @@ Default: TRUE.}
 
 \item{overwrite}{Overwrite row names if they already exist. Default: TRUE.}
 
-\item{...}{Pass arguments to make.names()..}
+\item{...}{Pass arguments to make.names().}
 }
 \description{
 Converts the first column (or a specified column) of a dataframe or tibble into row names.
-This function differs from \code{tibble::column_to_rownames} in that it takes column names or inices and
+This function differs from \code{tibble::column_to_rownames} in that it takes column names or indices and
 it offers the option to sanitize row names using \code{make.names}, provides a warning if there are
 duplicated values in the row name column
 }

--- a/man/read.simple.csv.named.vector.Rd
+++ b/man/read.simple.csv.named.vector.Rd
@@ -27,7 +27,7 @@ read.simple.csv.named.vector(
 \item{...}{Additional arguments passed to \code{\link[readr]{read_csv}} or read_csv2.}
 }
 \description{
-Read in a data frame (csv), and extact a value and a name column, and convert them
+Read in a data frame (csv), and extract a value and a name column, and convert them
 to a named vector. By default, it assumes the names in the first column and the values
 excel style named vectors, names in col1,
 headers SHIFTED. The header should start with a TAB / First column name

--- a/man/read.simple.ssv.Rd
+++ b/man/read.simple.ssv.Rd
@@ -27,7 +27,7 @@ read.simple.ssv(
 \item{coltypes}{What type of variables are in columns? Auto-guessing can be very slow., Default: NULL}
 }
 \description{
-Space separeted values. Read in a file with excel style data:
+Space separated values. Read in a file with excel style data:
 rownames in col1, headers SHIFTED. The header should start with a
 TAB / First column name should be empty.
 }


### PR DESCRIPTION
## Summary
- Correct multiple README typos (indices, extract, separated) and remove extra punctuation
- Correct read.simple.xls helper to prompt gdata installation
- Set DESCRIPTION `Packaged` field to 2024-07-14 and fix related docs

## Testing
- `R -q -e "devtools::check(document = FALSE, run_dont_test = TRUE, manual = FALSE)"` *(fails: command not found)*
- `codespell` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893218d6370832c9752b8bb1fd26b36