### PR TITLE
Fix NA replacement in read.simple.table to preserve column classes

### DIFF
--- a/R/ReadWriter.R
+++ b/R/ReadWriter.R
@@ -299,7 +299,9 @@ read.simple.table <- function(..., colnames = TRUE, coltypes = NULL) {
   # read_in = read.table( pfn , stringsAsFactors = FALSE, sep = "\t", header = colnames )
   read_in <- readr::read_tsv(pfn, col_names = colnames, col_types = coltypes)
   iprint("New variable dim: ", dim(read_in))
-  read_in <- as.data.frame(gtools::na.replace(data.matrix(read_in), replace = 0))
+
+  # Preserve column classes when replacing missing values
+  read_in <- as.data.frame(gtools::na.replace(read_in, replace = 0))
   return(read_in)
 }
 


### PR DESCRIPTION
## Summary
- avoid coercing tsv input to a numeric matrix when replacing missing values in `read.simple.table`
- preserve original column classes so character data is not lost when converting to a data frame

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_692ef30502c08323bb5a8474ae62502e)